### PR TITLE
Create keychain timeout parameter

### DIFF
--- a/fastlane/actions/build_setup.rb
+++ b/fastlane/actions/build_setup.rb
@@ -33,7 +33,7 @@ module Fastlane
           default_keychain: false,
           password: keychain_password,
           path: keychain_path,
-          timeout: false,
+          timeout: true,
           unlock: true
         )
         should_log && UI.message("Finished creating keychain at #{keychain_path}.")

--- a/fastlane/actions/build_setup.rb
+++ b/fastlane/actions/build_setup.rb
@@ -33,7 +33,7 @@ module Fastlane
           default_keychain: false,
           password: keychain_password,
           path: keychain_path,
-          timeout: true,
+          timeout: 0,
           unlock: true
         )
         should_log && UI.message("Finished creating keychain at #{keychain_path}.")


### PR DESCRIPTION
Changing the create_keychain timeout parameter from a bool to an int (see https://docs.fastlane.tools/actions/create_keychain/)