### PR TITLE
Feature/veracode

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -20,7 +20,6 @@ platform :ios do
        config = options[:config] || "Debug"
        build_number = options[:build_number] || ENV["BUILD_NUMBER"] || UI.user_error!("Please provide a 'build_number' that can be passed to gym in order to generate your Veracode build.")
        output_name = "#{scheme}_Veracode_#{build_number}"
-       UI.message(output_name)
 
        # Use gym to generate a debug build with appropriate build settings for Veracode
        # See https://help.veracode.com/reader/4EKhlLSMHm5jC8P8j3XccQ/PJWz14TuPBwScC2EpJtB2Q for more information
@@ -30,11 +29,11 @@ platform :ios do
                             clean: true,
                             output_directory: "./.build",
                             archive_path: "./.build/#{output_name}",
-                            derived_data_path: "./dd",
+                            derived_data_path: "./.dd",
                             skip_package_ipa: true,
                             xcargs: "DEBUG_INFORMATION_FORMAT='dwarf-with-dsym' ENABLE_BITCODE='YES'")
 
-       UI.message "xcarchive created at: '#{xcarchive_path}'"
+       UI.message "Created .xcarchive at: '#{xcarchive_path}'"
 
        # Convert the xcarchive into a .zip file suitable for upload to Veracode
        payload_path = _veracode_zip(
@@ -42,7 +41,7 @@ platform :ios do
            output_name: output_name
        )
 
-       UI.success "Created Veracode zip file at '#{payload_path}'"
+       UI.success "Created Veracode zip file at: '#{payload_path}'"
        # TODO: Create a custom action that will handle the uploading of the .bca file to Veracode
    end
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -31,19 +31,17 @@ platform :ios do
                             archive_path: "./.build/#{output_name}",
                             derived_data_path: "./dd",
                             skip_package_ipa: true,
-                            xcargs: "DEBUG_INFORMATION_FORMAT='dwarf-with-dsym' ENABLE_BITCODE='YES'",
-                            export_method: "development")
+                            xcargs: "DEBUG_INFORMATION_FORMAT='dwarf-with-dsym' ENABLE_BITCODE='YES'")
 
        UI.message "xcarchive created at: '#{xcarchive_path}'"
 
-       # # Convert the xcarchive into a .bca file suitable for upload to Veracode
-       # bca_payload_path = generate_veracode_bca(
-       #     xcarchive_path: xcarchive_path,
-       #     output_name: output_name
-       # )
-       #
-       # UI.success "Created Veracode bca file at '#{bca_payload_path}'"
+       # Convert the xcarchive into a .zip file suitable for upload to Veracode
+       payload_path = _veracode_zip(
+           xcarchive_path: xcarchive_path,
+           output_name: output_name
+       )
 
+       UI.success "Created Veracode zip file at '#{payload_path}'"
        # TODO: Create a custom action that will handle the uploading of the .bca file to Veracode
    end
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -20,6 +20,7 @@ platform :ios do
        config = options[:config] || "Debug"
        build_number = options[:build_number] || ENV["BUILD_NUMBER"] || UI.user_error!("Please provide a 'build_number' that can be passed to gym in order to generate your Veracode build.")
        output_name = "#{scheme}_Veracode_#{build_number}"
+       UI.message(output_name)
 
        # Use gym to generate a debug build with appropriate build settings for Veracode
        # See https://help.veracode.com/reader/4EKhlLSMHm5jC8P8j3XccQ/PJWz14TuPBwScC2EpJtB2Q for more information

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -15,7 +15,7 @@
 platform :ios do
 
    desc "Contains the core logic for generating and converting a build into a format suitable for upload to Veracode. Must provide a scheme (defaults to ENV['SCHEME']), config (defaults to 'Debug'), and build number (defaults to ENV['BUILD_NUMBER'])."
-   lane :buildVeracodeCore do |options|
+   lane :buildVeracodeArchive do |options|
        scheme = options[:scheme] || ENV["SCHEME"] || UI.user_error!("Please provide a 'scheme' that can be passed to gym in order to generate your Veracode build.")
        config = options[:config] || "Debug"
        build_number = options[:build_number] || ENV["BUILD_NUMBER"] || UI.user_error!("Please provide a 'build_number' that can be passed to gym in order to generate your Veracode build.")
@@ -31,36 +31,19 @@ platform :ios do
                             archive_path: "./.build/#{output_name}",
                             derived_data_path: "./dd",
                             skip_package_ipa: true,
-                            xcargs: "DEBUG_INFORMATION_FORMAT='dwarf-with-dsym' ENABLE_BITCODE='YES'")
+                            xcargs: "DEBUG_INFORMATION_FORMAT='dwarf-with-dsym' ENABLE_BITCODE='YES'",
+                            export_method: "development")
 
        UI.message "xcarchive created at: '#{xcarchive_path}'"
 
-       # Convert the xcarchive into a .bca file suitable for upload to Veracode
-       bca_payload_path = generate_veracode_bca(
-           xcarchive_path: xcarchive_path,
-           output_name: output_name
-       )
-
-       UI.success "Created Veracode bca file at '#{bca_payload_path}'"
+       # # Convert the xcarchive into a .bca file suitable for upload to Veracode
+       # bca_payload_path = generate_veracode_bca(
+       #     xcarchive_path: xcarchive_path,
+       #     output_name: output_name
+       # )
+       #
+       # UI.success "Created Veracode bca file at '#{bca_payload_path}'"
 
        # TODO: Create a custom action that will handle the uploading of the .bca file to Veracode
    end
-
-   desc "Wraps the 'buildVeracodeCore' lane in keychain setup/cleanup with proper error handling logic."
-   lane :buildVeracode do |options|
-       scheme = options[:scheme]
-       config = options[:config]
-       build_number = options[:build_number]
-
-       setup
-       begin
-           buildVeracodeCore(scheme: scheme, config: config, build_number: build_number)
-       rescue => exception
-           cleanup
-           raise exception
-       else
-           cleanup
-       end
-   end
-
 end

--- a/fastlane/actions/veracode_zip.rb
+++ b/fastlane/actions/veracode_zip.rb
@@ -1,0 +1,66 @@
+module Fastlane
+  module Actions
+    class VeracodeZipAction < Action
+
+      # Support
+      def self.is_supported?(platform)
+        platform == :ios
+      end
+
+      # Run
+      def self.run(params)
+        xcarchive_path = params[:xcarchive_path]
+        output_name = params[:output_name]
+
+        Dir.chdir("#{xcarchive_path}") do
+            payload_path = "../#{output_name}.zip"
+            sh("zip -r #{payload_path}")
+
+            final_payload_path = File.expand_path(payload_path)
+
+            # Return the path to the created .bca file
+            final_payload_path
+        end
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Converts a .xcarchive into a .zip file suitable for upload to Veracode"
+      end
+
+      def self.return_value
+        "Returns the absolute path to the generated .bca file"
+      end
+
+      def self.authors
+        ["Tyler Milner - @tylermilner on GitHub",
+         "Will McGinty - @wmcginty on GitHub"]
+      end
+
+      def self.details
+        "Converts a .xcarchive into a .zip file suitable for upload to the Veracode platform for static analysis security scanning. Follows the manual steps listed in the 'Packaging Guidance' section of Veracode's iOS compilation instructions. For more information, see https://help.veracode.com/reader/4EKhlLSMHm5jC8P8j3XccQ/PJWz14TuPBwScC2EpJtB2Q#ios__guidance"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :xcarchive_path,
+                                       description: "The path to the .xcarchive file to be converted into the Veracode .bca",
+                                       type: String,
+                                       verify_block: proc do |value|
+                                          UI.user_error!("A non-empty xcarchive path must be provided") unless (value and not value.empty?)
+                                       end),
+
+          FastlaneCore::ConfigItem.new(key: :output_name,
+                                       description: "The file name to be used for the generated .bca file (not including the '.bca' extension)",
+                                       type: String,
+                                       verify_block: proc do |value|
+                                          UI.user_error!("A non-empty output file name must be provided") unless (value and not value.empty?)
+                                       end)
+        ]
+      end
+    end
+  end
+end

--- a/fastlane/actions/veracode_zip.rb
+++ b/fastlane/actions/veracode_zip.rb
@@ -10,7 +10,7 @@ module Fastlane
       # Run
       def self.run(params)
         xcarchive_path = params[:xcarchive_path]
-        output_name = File.sanitize(params[:output_name])
+        output_name = sanitize(params[:output_name])
 
         Dir.chdir("#{xcarchive_path}") do
             payload_path = "../#{output_name}.zip"
@@ -21,6 +21,20 @@ module Fastlane
             # Return the path to the created .bca file
             final_payload_path
         end
+      end
+
+
+      # Helper
+
+      def self.sanitize(filename)
+        # Bad as defined by wikipedia: https://en.wikipedia.org/wiki/Filename#Reserved_characters_and_words
+        # Adapted from: http://gavinmiller.io/2016/creating-a-secure-sanitization-function/
+        block_list = ['/', '\\', '?', '%', '*', ':', '|', '"', '<', '>', '.', ' ']
+        block_list.each do |char|
+          filename.gsub!(char, '_')
+        end
+
+        filename
       end
 
       #####################################################

--- a/fastlane/actions/veracode_zip.rb
+++ b/fastlane/actions/veracode_zip.rb
@@ -11,6 +11,7 @@ module Fastlane
       def self.run(params)
         xcarchive_path = params[:xcarchive_path]
         output_name = params[:output_name]
+        UI.message(output_name)
 
         Dir.chdir("#{xcarchive_path}") do
             payload_path = "../#{output_name}.zip"

--- a/fastlane/actions/veracode_zip.rb
+++ b/fastlane/actions/veracode_zip.rb
@@ -16,7 +16,7 @@ module Fastlane
             payload_path = "../#{output_name}.zip"
             sh("zip -r #{payload_path} $(ls)")
 
-# Return the path to the created .bca file
+            # Return the path to the created .bca file
             final_payload_path = File.expand_path(payload_path)
             final_payload_path
         end

--- a/fastlane/actions/veracode_zip.rb
+++ b/fastlane/actions/veracode_zip.rb
@@ -14,7 +14,7 @@ module Fastlane
 
         Dir.chdir("#{xcarchive_path}") do
             payload_path = "../#{output_name}.zip"
-            sh("zip -r #{payload_path}")
+            sh("zip -r #{payload_path} $(ls)")
 
             final_payload_path = File.expand_path(payload_path)
 

--- a/fastlane/actions/veracode_zip.rb
+++ b/fastlane/actions/veracode_zip.rb
@@ -10,8 +10,7 @@ module Fastlane
       # Run
       def self.run(params)
         xcarchive_path = params[:xcarchive_path]
-        output_name = params[:output_name]
-        UI.message(output_name)
+        output_name = File.sanitize(params[:output_name])
 
         Dir.chdir("#{xcarchive_path}") do
             payload_path = "../#{output_name}.zip"

--- a/fastlane/actions/veracode_zip.rb
+++ b/fastlane/actions/veracode_zip.rb
@@ -16,9 +16,8 @@ module Fastlane
             payload_path = "../#{output_name}.zip"
             sh("zip -r #{payload_path} $(ls)")
 
+# Return the path to the created .bca file
             final_payload_path = File.expand_path(payload_path)
-
-            # Return the path to the created .bca file
             final_payload_path
         end
       end
@@ -26,6 +25,7 @@ module Fastlane
 
       # Helper
 
+      # Attempts to sanitize the output name in the case it contains reserved characters
       def self.sanitize(filename)
         # Bad as defined by wikipedia: https://en.wikipedia.org/wiki/Filename#Reserved_characters_and_words
         # Adapted from: http://gavinmiller.io/2016/creating-a-secure-sanitization-function/


### PR DESCRIPTION
This PR simplifies the flow to create a Veracode archive and migrates from the old `bca` packaging to the now default `zip` packaging. 

-Unofficially deprecate the existing `generate_veracode_bca` action in favor of the `veracode_zip` action, now that Veracode asks for a simple `zip` archive of the build `.xcarchive`. I have left the old action in place and unmodified until such a time as we decide to remove it. Having said that, I'm not sure how many people (if any) are currently using Veracode with new Jenkins, so it may be best to go ahead and remove now to reduce confusion. Thoughts?

-Remove the existing `buildVeracode` lane - it made assumptions about the names of build set up and clean up actions that are not defined in this repository. For that reason, it has been replaced with a single `buildVeracodeArchive` lane that relies on code signing being setup and cleaned up outside of its scope.